### PR TITLE
Load UCX libs explicitly

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleManager.scala
@@ -14,6 +14,7 @@ import org.apache.spark.shuffle.ucx.rpc.UcxRpcMessages.{ExecutorAdded, Introduce
 import org.apache.spark.shuffle.ucx.utils.SerializableDirectBuffer
 import org.apache.spark.util.{RpcUtils, ThreadUtils}
 import org.apache.spark.{SecurityManager, SparkConf, SparkEnv}
+import org.openucx.jucx.NativeLibs
 
 /**
  * Common part for all spark versions for UcxShuffleManager logic
@@ -22,6 +23,10 @@ abstract class CommonUcxShuffleManager(val conf: SparkConf, isDriver: Boolean) e
   type ShuffleId = Int
   type MapId = Int
   type ReduceId = Long
+
+  if (!isDriver) {
+    NativeLibs.load();
+  }
 
   val ucxShuffleConf = new UcxShuffleConf(conf)
 


### PR DESCRIPTION
# What
 Fix SIGSEGV issue

# Why ?
UCX should be initialized in the main thread to avoid collisions with JVM when malloc/mmap hook is registered.

# How ?
Load the ucx library once ucx shuffle manager is created